### PR TITLE
Fix issue where only one function would be imported by name

### DIFF
--- a/thesmuggler.py
+++ b/thesmuggler.py
@@ -28,7 +28,7 @@ def smuggle(*args, **kwargs):
     source = kwargs.pop('source', None)
 
     # Be careful when moving the contents of this
-    module_file = args[0] if len(args) == 1 else source
+    module_file = args[0] if source is None else source
 
     module_name = os.path.splitext(os.path.basename(module_file))[0]
 
@@ -49,7 +49,7 @@ def smuggle(*args, **kwargs):
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
 
-    if len(args) == 1:
+    if len(args) == 0 or (len(args) == 1 and source is None):
         return module
 
     # Can't use a comprehension here since module wouldn't be in the


### PR DESCRIPTION
With the previous code, as I see it, something like this:

```py
read_all_data = smuggle("read_all_data", source=os.path.join(
    os.path.abspath(os.path.dirname(__file__)), "read_all_data.py"))
```

would lead to `os.path.isabs(module_file)` to be false, and various consequences, simply because len(args) == 1, even though the passed argument is the name of the function to import from the file specified by source.